### PR TITLE
Assume UTF8 encoding in JSON

### DIFF
--- a/utils/helperMethods.py
+++ b/utils/helperMethods.py
@@ -28,7 +28,7 @@ def getFileNameFromPath(path) -> str:
 
 def readJSON(path) -> dict:
     try:
-        with open(path) as f:
+        with open(path, encoding="utf8") as f:
             return json.load(f)
     except:
         return {}


### PR DESCRIPTION
This not only fixes loading goofy high order unicode strings but also
japanese characters and such. 

Old style escaped unicode strings will still also work fine.